### PR TITLE
More generic formats allowing to pass the caninical tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,14 +12,16 @@ let package = Package(
       name: "Todotxt",
       targets: ["Todotxt"])
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-markdown", from: "0.3.0")
+  ],
   targets: [
     .target(
       name: "Todotxt",
       dependencies: ["Builder", "Object"]),
     .target(
       name: "Builder",
-      dependencies: ["Object"]),
+      dependencies: ["Object", .product(name: "Markdown", package: "swift-markdown")]),
     .target(
       name: "Object"),
     .testTarget(

--- a/Sources/Builder/TodoBuilder.swift
+++ b/Sources/Builder/TodoBuilder.swift
@@ -11,8 +11,8 @@
         isCompletion: Completion.build(input: input),
         priority: Priority.build(input: input), dates: DateManagement.build(input: input),
         title: Title.build(input: input),
-        project: Project.build(input: input),
-        context: Context.build(input: input),
+        projects: Project.build(input: input),
+        contexts: Context.build(input: input),
         dueDate: DueDate.build(input: input),
         attributes: KeyValueAttributes.build(input: input)
       )
@@ -132,7 +132,7 @@
 
   extension TodoBuilder {
     enum Project: TodoRegexable {
-      static func build(input: String) -> Todo.Project? {
+      static func build(input: String) -> [Todo.Project] {
         let reference = Reference(Todo.Project.self)
         let regex = Regex {
           ChoiceOf {
@@ -148,12 +148,7 @@
             })
         }
         
-        let match = input.firstMatch(of: regex)
-        if let match {
-          return match[reference]
-        } else {
-          return nil
-        }
+        return input.matches(of: regex).map({ $0[reference] })
       }
     }
   }
@@ -162,7 +157,7 @@
 
   extension TodoBuilder {
     enum Context: TodoRegexable {
-      static func build(input: String) -> Todo.Context? {
+      static func build(input: String) -> [Todo.Context] {
         let reference = Reference(Todo.Context.self)
         let regex = Regex {
           ChoiceOf {
@@ -178,12 +173,7 @@
             })
         }
         
-        let match = input.firstMatch(of: regex)
-        if let match {
-          return match[reference]
-        } else {
-          return nil
-        }
+        return input.matches(of: regex).map({ $0[reference] })
       }
     }
   }

--- a/Sources/Builder/TodoBuilder.swift
+++ b/Sources/Builder/TodoBuilder.swift
@@ -93,7 +93,19 @@
           }
         }
         let regex = Regex {
-          One(.whitespace)
+          Anchor.startOfLine
+          ZeroOrMore {
+            ChoiceOf {
+              One("x ")
+              OneOrMore {
+                "("
+                (try? Regex("[A-Z]"))!
+                ") "
+              }
+              One(.iso8601Date(timeZone: .gmt))
+              One(.whitespace)
+            }
+          }
           NegativeLookahead {
             ChoiceOf {
               One(.iso8601Date(timeZone: .gmt))

--- a/Sources/Builder/TodoBuilder.swift
+++ b/Sources/Builder/TodoBuilder.swift
@@ -84,12 +84,8 @@
           ChoiceOf {
             One(.whitespace)
             OneOrMore(.word)
-          }
-          NegativeLookahead {
-            OneOrMore {
-              OneOrMore(.word)
-              One(":")
-            }
+            OneOrMore(.digit)
+            OneOrMore(.anyOf("-_,;.\'\""))
           }
         }
         let regex = Regex {
@@ -106,9 +102,13 @@
               One(.whitespace)
             }
           }
-          NegativeLookahead {
+          Capture(titlematch, as: reference,
+                  transform: { word -> String in String(word) })
+          Lookahead {
             ChoiceOf {
-              One(.iso8601Date(timeZone: .gmt))
+              Anchor.endOfLine
+              One(" +")
+              One(" @")
               OneOrMore {
                 One(.whitespace)
                 OneOrMore(.word)
@@ -116,13 +116,11 @@
               }
             }
           }
-          Capture(titlematch, as: reference,
-                  transform: { word -> String in String(word) })
         }
         
         let match = input.firstMatch(of: regex)
         if let match {
-          return match[reference].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) // because we capture the last space
+          return match[reference].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) // because we sometimes capture the last space
         } else {
           return nil
         }

--- a/Sources/Object/Todo.swift
+++ b/Sources/Object/Todo.swift
@@ -7,6 +7,8 @@ import Foundation
 public struct Todo: Identifiable, TodoRawRepresentable {
   public let id: ID
   public let isCompletion: Bool
+  public let completedAt: Date?
+  public let createdAt: Date?
   public let priority: Priority?
   public let title: String?
   public let project: Project?
@@ -18,6 +20,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     [
       completionRawTodoTxt,
       priority.map(\.rawTodoTxt),
+      completedRawTodoTxt,
+      createdRawTodoTxt,
       title,
       project.map(\.rawTodoTxt),
       context.map(\.rawTodoTxt),
@@ -41,11 +45,24 @@ public struct Todo: Identifiable, TodoRawRepresentable {
       "due:\(Todo.dueDateFormatter.string(from: date))"
     }
   }
-
+    
+  private var completedRawTodoTxt: String? {
+    completedAt.map { date in
+      "\(Todo.dueDateFormatter.string(from: date))"
+    }
+  }
+    
+  private var createdRawTodoTxt: String? {
+    createdAt.map { date in
+      "\(Todo.dueDateFormatter.string(from: date))"
+    }
+  }
+    
   public init(
     id: Todo.ID,
     isCompletion: Bool,
     priority: Todo.Priority?,
+    dates: (created: Date, completed: Date?)?,
     title: String?,
     project: Todo.Project?,
     context: Todo.Context?,
@@ -55,6 +72,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     self.id = id
     self.isCompletion = isCompletion
     self.priority = priority
+    self.createdAt = dates?.created
+    self.completedAt = dates?.completed
     self.title = title
     self.project = project
     self.context = context

--- a/Sources/Object/Todo.swift
+++ b/Sources/Object/Todo.swift
@@ -15,7 +15,7 @@ public struct Todo: Identifiable, TodoRawRepresentable {
   public let context: Context?
   public let dueDate: Date?
   public let attributes: [String:String]
-
+  
   public var rawTodoTxt: String {
     [
       completionRawTodoTxt,
@@ -28,36 +28,36 @@ public struct Todo: Identifiable, TodoRawRepresentable {
       dueRawTodoTxt,
       (self.attributes.map({ $0.key+":"+$0.value }).joined(separator: " ") as String?)
     ]
-    .reduce(into: "") { (result, string) in
-      if let string {
-        result.append(" \(string)")
+      .reduce(into: "") { (result, string) in
+        if let string {
+          result.append(" \(string)")
+        }
       }
-    }
-    .trimmingCharacters(in: .whitespaces)
+      .trimmingCharacters(in: .whitespaces)
   }
-
+  
   private var completionRawTodoTxt: String? {
     isCompletion ? "x" : nil
   }
-
+  
   private var dueRawTodoTxt: String? {
     dueDate.map { date in
       "due:\(Todo.dueDateFormatter.string(from: date))"
     }
   }
-    
+  
   private var completedRawTodoTxt: String? {
     completedAt.map { date in
       "\(Todo.dueDateFormatter.string(from: date))"
     }
   }
-    
+  
   private var createdRawTodoTxt: String? {
     createdAt.map { date in
       "\(Todo.dueDateFormatter.string(from: date))"
     }
   }
-    
+  
   public init(
     id: Todo.ID,
     isCompletion: Bool,
@@ -88,11 +88,11 @@ public struct Todo: Identifiable, TodoRawRepresentable {
 extension Todo {
   public struct ID: Codable, ExpressibleByStringLiteral, Hashable, RawRepresentable {
     public let rawValue: String
-
+    
     public init(rawValue: String) {
       self.rawValue = rawValue
     }
-
+    
     public init(stringLiteral value: String) {
       self.init(rawValue: value)
     }
@@ -104,15 +104,15 @@ extension Todo {
 extension Todo {
   public struct Priority: Comparable, TodoRawRepresentable {
     public let value: String
-
+    
     public var rawTodoTxt: String {
       "(\(value))"
     }
-
+    
     public init(_ string: String) {
       self.value = string
     }
-
+    
     public static func < (lhs: Todo.Priority, rhs: Todo.Priority) -> Bool {
       lhs.value < rhs.value
     }
@@ -124,15 +124,15 @@ extension Todo {
 extension Todo {
   public struct Project: Comparable, TodoRawRepresentable {
     public let title: String
-
+    
     public var rawTodoTxt: String {
       "+\(title)"
     }
-
+    
     public init(_ title: String) {
       self.title = title
     }
-
+    
     public static func < (lhs: Todo.Project, rhs: Todo.Project) -> Bool {
       lhs.title < rhs.title
     }
@@ -144,15 +144,15 @@ extension Todo {
 extension Todo {
   public struct Context: Comparable, TodoRawRepresentable {
     public let title: String
-
+    
     public var rawTodoTxt: String {
       "@\(title)"
     }
-
+    
     public init(_ title: String) {
       self.title = title
     }
-
+    
     public static func < (lhs: Todo.Context, rhs: Todo.Context) -> Bool {
       lhs.title < rhs.title
     }
@@ -172,7 +172,7 @@ extension Todo {
 
 // MARK: - Key Value support
 extension Todo {
-    public subscript(k:String) -> String? {
-        return self.attributes[k]
-    }
+  public subscript(k:String) -> String? {
+    return self.attributes[k]
+  }
 }

--- a/Sources/Object/Todo.swift
+++ b/Sources/Object/Todo.swift
@@ -11,8 +11,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
   public let createdAt: Date?
   public let priority: Priority?
   public let title: String?
-  public let project: Project?
-  public let context: Context?
+  public let projects: [Project]
+  public let contexts: [Context]
   public let dueDate: Date?
   public let attributes: [String:String]
   
@@ -23,13 +23,13 @@ public struct Todo: Identifiable, TodoRawRepresentable {
       completedRawTodoTxt,
       createdRawTodoTxt,
       title,
-      project.map(\.rawTodoTxt),
-      context.map(\.rawTodoTxt),
+      (projects.map(\.rawTodoTxt).joined(separator: " ") as String?),
+      (contexts.map(\.rawTodoTxt).joined(separator: " ") as String?),
       dueRawTodoTxt,
       (self.attributes.map({ $0.key+":"+$0.value }).joined(separator: " ") as String?)
     ]
       .reduce(into: "") { (result, string) in
-        if let string {
+        if let string, string != "" {
           result.append(" \(string)")
         }
       }
@@ -64,8 +64,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     priority: Todo.Priority?,
     dates: (created: Date, completed: Date?)?,
     title: String?,
-    project: Todo.Project?,
-    context: Todo.Context?,
+    projects: [Todo.Project],
+    contexts: [Todo.Context],
     dueDate: Date?,
     attributes: [String:String]? = nil
   ) {
@@ -75,8 +75,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     self.createdAt = dates?.created
     self.completedAt = dates?.completed
     self.title = title
-    self.project = project
-    self.context = context
+    self.projects = projects
+    self.contexts = contexts
     self.dueDate = dueDate
     if let attrs = attributes { self.attributes = attrs }
     else { self.attributes = [:] }

--- a/Sources/Object/Todo.swift
+++ b/Sources/Object/Todo.swift
@@ -12,6 +12,7 @@ public struct Todo: Identifiable, TodoRawRepresentable {
   public let project: Project?
   public let context: Context?
   public let dueDate: Date?
+  public let attributes: [String:String]
 
   public var rawTodoTxt: String {
     [
@@ -21,6 +22,7 @@ public struct Todo: Identifiable, TodoRawRepresentable {
       project.map(\.rawTodoTxt),
       context.map(\.rawTodoTxt),
       dueRawTodoTxt,
+      (self.attributes.map({ $0.key+":"+$0.value }).joined(separator: " ") as String?)
     ]
     .reduce(into: "") { (result, string) in
       if let string {
@@ -47,7 +49,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     title: String?,
     project: Todo.Project?,
     context: Todo.Context?,
-    dueDate: Date?
+    dueDate: Date?,
+    attributes: [String:String]? = nil
   ) {
     self.id = id
     self.isCompletion = isCompletion
@@ -56,6 +59,8 @@ public struct Todo: Identifiable, TodoRawRepresentable {
     self.project = project
     self.context = context
     self.dueDate = dueDate
+    if let attrs = attributes { self.attributes = attrs }
+    else { self.attributes = [:] }
   }
 }
 
@@ -144,4 +149,11 @@ extension Todo {
     formatter.locale = NSLocale.current
     return formatter
   }()
+}
+
+// MARK: - Key Value support
+extension Todo {
+    public subscript(k:String) -> String? {
+        return self.attributes[k]
+    }
 }

--- a/Sources/Object/TodoList.swift
+++ b/Sources/Object/TodoList.swift
@@ -58,9 +58,9 @@ extension TodoList {
     case .priority:
       return _sorted(by: \.priority)
     case .project:
-      return _sorted(by: \.project)
+      return _sorted(by: \.projects)
     case .context:
-      return _sorted(by: \.context)
+      return _sorted(by: \.contexts)
     }
   }
   
@@ -79,5 +79,32 @@ extension TodoList {
       }
     }
     return .init(sortedValue)
+  }
+  
+  /// Sorting by collection doesn't work by default. We use the first in alphabetical order
+  private func _sorted(by keyPath: KeyPath<Todo, Array<Todo.Context>>) -> TodoList {
+    return .init(value.sorted(by: { t1, t2 in t1.contexts < t2.contexts }))
+  }
+  
+  private func _sorted(by keyPath: KeyPath<Todo, Array<Todo.Project>>) -> TodoList {
+    return .init(value.sorted(by: { t1, t2 in t1.projects < t2.projects }))
+  }
+  
+}
+
+/// Sorting by collection doesn't work by default. We use the first in alphabetical order
+extension Array : Comparable where Element == Todo.Context {
+  public static func < (lhs: Array<Element>, rhs: Array<Element>) -> Bool {
+    if lhs.isEmpty { return false }
+    else if lhs.isEmpty { return true }
+    else { return lhs.sorted().first! < rhs.sorted().first! }
+  }
+}
+
+extension Array where Element == Todo.Project {
+  public static func < (lhs: Array<Element>, rhs: Array<Element>) -> Bool {
+    if lhs.isEmpty { return false }
+    else if lhs.isEmpty { return true }
+    else { return lhs.sorted().first! < rhs.sorted().first! }
   }
 }

--- a/Sources/Object/TodoList.swift
+++ b/Sources/Object/TodoList.swift
@@ -1,15 +1,15 @@
 /// Objects corresponding to one line of Todo.txt file
 public struct TodoList: ExpressibleByArrayLiteral, Sequence {
   public var value: [Todo]
-
+  
   public init(_ value: [Todo]) {
     self.value = value
   }
-
+  
   public init(arrayLiteral elements: Todo...) {
     self.init(elements)
   }
-
+  
   public func makeIterator() -> TodoListIterator {
     TodoListIterator(self)
   }
@@ -19,14 +19,14 @@ public struct TodoList: ExpressibleByArrayLiteral, Sequence {
 
 public struct TodoListIterator: IteratorProtocol {
   public typealias Element = Todo
-
+  
   private let list: TodoList
   private var index: Int = 0
-
+  
   fileprivate init(_ _todoList: TodoList) {
     self.list = _todoList
   }
-
+  
   public mutating func next() -> Element? {
     defer { index += 1 }
     guard index < list.value.count else {
@@ -46,7 +46,7 @@ extension TodoList {
     case project
     case context
   }
-
+  
   /// Sort by ``Todo`` object property.
   ///
   /// - Parameter type: sorting key type.
@@ -63,7 +63,7 @@ extension TodoList {
       return _sorted(by: \.context)
     }
   }
-
+  
   /// - Note: default order: *ascending*
   private func _sorted<T: Comparable>(by keyPath: KeyPath<Todo, T?>) -> TodoList {
     let sortedValue = value.sorted { lhs, rhs in

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -8,10 +8,10 @@ final class TodoBuilderTests: XCTestCase {
     let input = "x (A) title +project @context due:2022-09-25"
     let todo = TodoBuilder.build(input: input)
     let output = todo.rawTodoTxt
-
+    
     XCTAssertEqual(input, output)
   }
-
+  
   func testBuildInputs() {
     let inputs = """
       x (A) title_1 +project @context due:2022-09-25
@@ -31,99 +31,99 @@ final class TodoBuilderTests: XCTestCase {
       """.components(separatedBy: "\n")
     let todoList = TodoBuilder.build(inputs: inputs)
     let outputs = todoList.value.map(\.rawTodoTxt)
-
+    
     XCTAssertEqual(inputs, outputs)
   }
+  
+  func testBuildInputWithKeys() {
+    let input = "x (A) title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
+    let todo = TodoBuilder.build(input: input)
+    let id = todo["id"]
+    let foo = todo["foo"]
+    let tags = todo["tags"]
     
-    func testBuildInputWithKeys() {
-        let input = "x (A) title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
-        let todo = TodoBuilder.build(input: input)
-        let id = todo["id"]
-        let foo = todo["foo"]
-        let tags = todo["tags"]
-        
-        XCTAssertEqual(id, "17")
-        XCTAssertEqual(foo, "bar")
-        XCTAssertEqual(tags, "bla,bli,blu")
-        
-        let rawOut = todo.rawTodoTxt
-        // no guarantee for the order of the keys
-        XCTAssert(rawOut.contains("id:17"))
-        XCTAssert(rawOut.contains("foo:bar"))
-        XCTAssert(rawOut.contains("tags:bla,bli,blu"))
-    }
+    XCTAssertEqual(id, "17")
+    XCTAssertEqual(foo, "bar")
+    XCTAssertEqual(tags, "bla,bli,blu")
     
-    func testBuildCompletedInputWithKeys() {
-        let input = "x (A) 2022-09-26 title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
-        let todo = TodoBuilder.build(input: input)
-        let id = todo["id"]
-        let foo = todo["foo"]
-        let tags = todo["tags"]
-        
-        XCTAssertEqual(id, "17")
-        XCTAssertEqual(foo, "bar")
-        XCTAssertEqual(tags, "bla,bli,blu")
-        
-        let rawOut = todo.rawTodoTxt
-        // no guarantee for the order of the keys
-        XCTAssert(rawOut.contains("id:17"))
-        XCTAssert(rawOut.contains("foo:bar"))
-        XCTAssert(rawOut.contains("tags:bla,bli,blu"))
-    }
+    let rawOut = todo.rawTodoTxt
+    // no guarantee for the order of the keys
+    XCTAssert(rawOut.contains("id:17"))
+    XCTAssert(rawOut.contains("foo:bar"))
+    XCTAssert(rawOut.contains("tags:bla,bli,blu"))
+  }
+  
+  func testBuildCompletedInputWithKeys() {
+    let input = "x (A) 2022-09-26 title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
+    let todo = TodoBuilder.build(input: input)
+    let id = todo["id"]
+    let foo = todo["foo"]
+    let tags = todo["tags"]
     
-    // Canonical examples from https://github.com/todotxt/todo.txt
-    func testCanonical() {
-        let ex1 = TodoBuilder.build(input: "x (A) 2016-05-20 2016-04-30 measure space for +chapelShelving @chapel due:2016-05-30")
-        XCTAssertTrue(ex1.isCompletion)
-        XCTAssertEqual(ex1.priority?.value,"A")
-        XCTAssertEqual(ex1.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 4, day: 30).date)
-        XCTAssertEqual(ex1.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 20).date)
-        XCTAssertEqual(ex1.title, "measure space for")
-        XCTAssertEqual(ex1.project?.title, "chapelShelving")
-        XCTAssertEqual(ex1.context?.title, "chapel")
-        XCTAssertEqual(ex1.dueDate, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 30).date)
-        
-        // Incomplete Tasks: Format Rule 1
-        let ex2 = TodoBuilder.build(inputs:"""
+    XCTAssertEqual(id, "17")
+    XCTAssertEqual(foo, "bar")
+    XCTAssertEqual(tags, "bla,bli,blu")
+    
+    let rawOut = todo.rawTodoTxt
+    // no guarantee for the order of the keys
+    XCTAssert(rawOut.contains("id:17"))
+    XCTAssert(rawOut.contains("foo:bar"))
+    XCTAssert(rawOut.contains("tags:bla,bli,blu"))
+  }
+  
+  // Canonical examples from https://github.com/todotxt/todo.txt
+  func testCanonical() {
+    let ex1 = TodoBuilder.build(input: "x (A) 2016-05-20 2016-04-30 measure space for +chapelShelving @chapel due:2016-05-30")
+    XCTAssertTrue(ex1.isCompletion)
+    XCTAssertEqual(ex1.priority?.value,"A")
+    XCTAssertEqual(ex1.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 4, day: 30).date)
+    XCTAssertEqual(ex1.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 20).date)
+    XCTAssertEqual(ex1.title, "measure space for")
+    XCTAssertEqual(ex1.project?.title, "chapelShelving")
+    XCTAssertEqual(ex1.context?.title, "chapel")
+    XCTAssertEqual(ex1.dueDate, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 30).date)
+    
+    // Incomplete Tasks: Format Rule 1
+    let ex2 = TodoBuilder.build(inputs:"""
 (A) Call Mom
 Really gotta call Mom (A) @phone @someday
 (b) Get back to the boss
 (B)->Submit TPS report
 """.components(separatedBy: CharacterSet.newlines))
-        XCTAssertEqual(ex2.value[0].priority?.value, "A")
-        XCTAssertNil(ex2.value[1].priority)
-        XCTAssertNil(ex2.value[2].priority)
-        XCTAssertNil(ex2.value[3].priority)
-        
-        // Incomplete Tasks: Format Rule 2
-        let ex3 = TodoBuilder.build(inputs:"""
+    XCTAssertEqual(ex2.value[0].priority?.value, "A")
+    XCTAssertNil(ex2.value[1].priority)
+    XCTAssertNil(ex2.value[2].priority)
+    XCTAssertNil(ex2.value[3].priority)
+    
+    // Incomplete Tasks: Format Rule 2
+    let ex3 = TodoBuilder.build(inputs:"""
 2011-03-02 Document +TodoTxt task format
 (A) 2011-03-02 Call Mom
 (A) Call Mom 2011-03-02
 """.components(separatedBy: CharacterSet.newlines))
-        XCTAssertNotNil(ex3.value[0].createdAt)
-        XCTAssertNotNil(ex3.value[1].createdAt)
-        XCTAssertNil(ex3.value[2].createdAt)
-        
-        // Incomplete Tasks: Format Rule 3
-        // TODO: would need making significant changes to the way the structure works by allowing more than one project/context
-        
-        // Complete Tasks: Format Rule 1
-        let ex4 = TodoBuilder.build(inputs:"""
+    XCTAssertNotNil(ex3.value[0].createdAt)
+    XCTAssertNotNil(ex3.value[1].createdAt)
+    XCTAssertNil(ex3.value[2].createdAt)
+    
+    // Incomplete Tasks: Format Rule 3
+    // TODO: would need making significant changes to the way the structure works by allowing more than one project/context
+    
+    // Complete Tasks: Format Rule 1
+    let ex4 = TodoBuilder.build(inputs:"""
 x 2011-03-03 Call Mom
 xylophone lesson
 X 2012-01-01 Make resolutions
 (A) x Find ticket prices
 """.components(separatedBy: CharacterSet.newlines))
-        XCTAssertTrue(ex4.value[0].isCompletion)
-        XCTAssertFalse(ex4.value[1].isCompletion)
-        XCTAssertFalse(ex4.value[2].isCompletion)
-        XCTAssertFalse(ex4.value[3].isCompletion)
-        
-        // Complete Tasks: Format Rule 2
-        let ex5 = TodoBuilder.build(input: "x 2011-03-02 2011-03-01 Review Tim's pull request +TodoTxtTouch @github")
-        XCTAssertTrue(ex5.isCompletion)
-        XCTAssertEqual(ex5.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 1).date)
-        XCTAssertEqual(ex5.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 2).date)
-    }
+    XCTAssertTrue(ex4.value[0].isCompletion)
+    XCTAssertFalse(ex4.value[1].isCompletion)
+    XCTAssertFalse(ex4.value[2].isCompletion)
+    XCTAssertFalse(ex4.value[3].isCompletion)
+    
+    // Complete Tasks: Format Rule 2
+    let ex5 = TodoBuilder.build(input: "x 2011-03-02 2011-03-01 Review Tim's pull request +TodoTxtTouch @github")
+    XCTAssertTrue(ex5.isCompletion)
+    XCTAssertEqual(ex5.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 1).date)
+    XCTAssertEqual(ex5.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 2).date)
+  }
 }

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -35,7 +35,9 @@ final class TodoBuilderTests: XCTestCase {
     let todoList = TodoBuilder.build(inputs: inputs)
     let outputs = todoList.value.map(\.rawTodoTxt)
     
-    XCTAssertEqual(inputs, outputs)
+    for idx in 0..<inputs.count {
+      XCTAssertEqual(inputs[idx], outputs[idx], "error with line \(idx): \(inputs[idx])")
+    }
   }
   
   func testBuildInputWithKeys() {
@@ -75,7 +77,7 @@ final class TodoBuilderTests: XCTestCase {
   }
   
   // Canonical examples from https://github.com/todotxt/todo.txt
-  func testCanonical() {
+  func testCanonical1() {
     let ex1 = TodoBuilder.build(input: "x (A) 2016-05-20 2016-04-30 measure space for +chapelShelving @chapel due:2016-05-30")
     XCTAssertTrue(ex1.isCompletion)
     XCTAssertEqual(ex1.priority?.value,"A")
@@ -109,8 +111,17 @@ Really gotta call Mom (A) @phone @someday
     XCTAssertNil(ex3.value[2].createdAt)
     
     // Incomplete Tasks: Format Rule 3
-    // TODO: would need making significant changes to the way the structure works by allowing more than one project/context
+    let exm = TodoBuilder.build(inputs:"""
+(A) Call Mom +Family +PeaceLoveAndHappiness @iphone @phone
+Email SoAndSo at soandso@example.com
+Learn how to add 2+2
+""".components(separatedBy: CharacterSet.newlines))
+    XCTAssertNotNil(exm.value[0].context) // TODO: multiple
+    XCTAssertNil(exm.value[1].context)
+    XCTAssertNil(exm.value[2].context)
+  }
     
+  func testCanonical2() {
     // Complete Tasks: Format Rule 1
     let ex4 = TodoBuilder.build(inputs:"""
 x 2011-03-03 Call Mom

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -28,6 +28,9 @@ final class TodoBuilderTests: XCTestCase {
       (A) 2022-09-25 2022-09-15 date7 due:2022-09-20
       x (A) 2022-09-25 2022-09-15 date8 due:2022-09-20
       x (A) 2022-09-25 2022-09-15 date8 tag:2022-09-20
+      something
+      something @context
+      something +project
       """.components(separatedBy: "\n")
     let todoList = TodoBuilder.build(inputs: inputs)
     let outputs = todoList.value.map(\.rawTodoTxt)

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -25,4 +25,41 @@ final class TodoBuilderTests: XCTestCase {
 
     XCTAssertEqual(inputs, outputs)
   }
+    
+    func testBuildInputWithKeys() {
+        let input = "x (A) title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
+        let todo = TodoBuilder.build(input: input)
+        let id = todo["id"]
+        let foo = todo["foo"]
+        let tags = todo["tags"]
+        
+        XCTAssertEqual(id, "17")
+        XCTAssertEqual(foo, "bar")
+        XCTAssertEqual(tags, "bla,bli,blu")
+        
+        let rawOut = todo.rawTodoTxt
+        // no guarantee for the order of the keys
+        XCTAssert(rawOut.contains("id:17"))
+        XCTAssert(rawOut.contains("foo:bar"))
+        XCTAssert(rawOut.contains("tags:bla,bli,blu"))
+    }
+    
+    func testBuildCompletedInputWithKeys() {
+        let input = "x (A) 2022-09-26 title +project @context due:2022-09-25 id:17 foo:bar tags:bla,bli,blu"
+        let todo = TodoBuilder.build(input: input)
+        let id = todo["id"]
+        let foo = todo["foo"]
+        let tags = todo["tags"]
+        
+        XCTAssertEqual(id, "17")
+        XCTAssertEqual(foo, "bar")
+        XCTAssertEqual(tags, "bla,bli,blu")
+        
+        let rawOut = todo.rawTodoTxt
+        // no guarantee for the order of the keys
+        XCTAssert(rawOut.contains("id:17"))
+        XCTAssert(rawOut.contains("foo:bar"))
+        XCTAssert(rawOut.contains("tags:bla,bli,blu"))
+    }
+    
 }

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -84,8 +84,8 @@ final class TodoBuilderTests: XCTestCase {
     XCTAssertEqual(ex1.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 4, day: 30).date)
     XCTAssertEqual(ex1.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 20).date)
     XCTAssertEqual(ex1.title, "measure space for")
-    XCTAssertEqual(ex1.project?.title, "chapelShelving")
-    XCTAssertEqual(ex1.context?.title, "chapel")
+    XCTAssert(ex1.projects.contains(where: { $0.title == "chapelShelving" }))
+    XCTAssert(ex1.contexts.contains(where: { $0.title == "chapel" }))
     XCTAssertEqual(ex1.dueDate, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 30).date)
     
     // Incomplete Tasks: Format Rule 1
@@ -116,9 +116,13 @@ Really gotta call Mom (A) @phone @someday
 Email SoAndSo at soandso@example.com
 Learn how to add 2+2
 """.components(separatedBy: CharacterSet.newlines))
-    XCTAssertNotNil(exm.value[0].context) // TODO: multiple
-    XCTAssertNil(exm.value[1].context)
-    XCTAssertNil(exm.value[2].context)
+    XCTAssertFalse(exm.value[0].contexts.isEmpty)
+    XCTAssert(exm.value[1].contexts.isEmpty)
+    XCTAssert(exm.value[2].contexts.isEmpty)
+    
+    // bonus
+    XCTAssert(exm.value[0].contexts.count == 2)
+    XCTAssert(exm.value[0].projects.count == 2)
   }
     
   func testCanonical2() {

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -19,6 +19,15 @@ final class TodoBuilderTests: XCTestCase {
       (B) title_3 +project due:2022-09-27
       (C) title_4 @context due:2022-09-28
       (A) title_5 due:2022-09-29
+      2022-09-25 date1 due:2022-09-20
+      x 2022-09-25 date2 due:2022-09-20
+      (A) 2022-09-25 date3 due:2022-09-20
+      x (A) 2022-09-25 date4 due:2022-09-20
+      2022-09-25 2022-09-15 date5 due:2022-09-20
+      x 2022-09-25 2022-09-15 date6 due:2022-09-20
+      (A) 2022-09-25 2022-09-15 date7 due:2022-09-20
+      x (A) 2022-09-25 2022-09-15 date8 due:2022-09-20
+      x (A) 2022-09-25 2022-09-15 date8 tag:2022-09-20
       """.components(separatedBy: "\n")
     let todoList = TodoBuilder.build(inputs: inputs)
     let outputs = todoList.value.map(\.rawTodoTxt)
@@ -62,4 +71,59 @@ final class TodoBuilderTests: XCTestCase {
         XCTAssert(rawOut.contains("tags:bla,bli,blu"))
     }
     
+    // Canonical examples from https://github.com/todotxt/todo.txt
+    func testCanonical() {
+        let ex1 = TodoBuilder.build(input: "x (A) 2016-05-20 2016-04-30 measure space for +chapelShelving @chapel due:2016-05-30")
+        XCTAssertTrue(ex1.isCompletion)
+        XCTAssertEqual(ex1.priority?.value,"A")
+        XCTAssertEqual(ex1.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 4, day: 30).date)
+        XCTAssertEqual(ex1.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 20).date)
+        XCTAssertEqual(ex1.title, "measure space for")
+        XCTAssertEqual(ex1.project?.title, "chapelShelving")
+        XCTAssertEqual(ex1.context?.title, "chapel")
+        XCTAssertEqual(ex1.dueDate, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2016, month: 5, day: 30).date)
+        
+        // Incomplete Tasks: Format Rule 1
+        let ex2 = TodoBuilder.build(inputs:"""
+(A) Call Mom
+Really gotta call Mom (A) @phone @someday
+(b) Get back to the boss
+(B)->Submit TPS report
+""".components(separatedBy: CharacterSet.newlines))
+        XCTAssertEqual(ex2.value[0].priority?.value, "A")
+        XCTAssertNil(ex2.value[1].priority)
+        XCTAssertNil(ex2.value[2].priority)
+        XCTAssertNil(ex2.value[3].priority)
+        
+        // Incomplete Tasks: Format Rule 2
+        let ex3 = TodoBuilder.build(inputs:"""
+2011-03-02 Document +TodoTxt task format
+(A) 2011-03-02 Call Mom
+(A) Call Mom 2011-03-02
+""".components(separatedBy: CharacterSet.newlines))
+        XCTAssertNotNil(ex3.value[0].createdAt)
+        XCTAssertNotNil(ex3.value[1].createdAt)
+        XCTAssertNil(ex3.value[2].createdAt)
+        
+        // Incomplete Tasks: Format Rule 3
+        // TODO: would need making significant changes to the way the structure works by allowing more than one project/context
+        
+        // Complete Tasks: Format Rule 1
+        let ex4 = TodoBuilder.build(inputs:"""
+x 2011-03-03 Call Mom
+xylophone lesson
+X 2012-01-01 Make resolutions
+(A) x Find ticket prices
+""".components(separatedBy: CharacterSet.newlines))
+        XCTAssertTrue(ex4.value[0].isCompletion)
+        XCTAssertFalse(ex4.value[1].isCompletion)
+        XCTAssertFalse(ex4.value[2].isCompletion)
+        XCTAssertFalse(ex4.value[3].isCompletion)
+        
+        // Complete Tasks: Format Rule 2
+        let ex5 = TodoBuilder.build(input: "x 2011-03-02 2011-03-01 Review Tim's pull request +TodoTxtTouch @github")
+        XCTAssertTrue(ex5.isCompletion)
+        XCTAssertEqual(ex5.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 1).date)
+        XCTAssertEqual(ex5.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 2).date)
+    }
 }

--- a/Tests/TodotxtTests/TodoBuilderTests.swift
+++ b/Tests/TodotxtTests/TodoBuilderTests.swift
@@ -144,4 +144,19 @@ X 2012-01-01 Make resolutions
     XCTAssertEqual(ex5.createdAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 1).date)
     XCTAssertEqual(ex5.completedAt, DateComponents(calendar: Calendar.current, timeZone: .gmt, year: 2011, month: 3, day: 2).date)
   }
+  
+  func testMarkdownLinks() {
+    let ex1 = TodoBuilder.build(inputs:"""
+x 2011-03-03 [Call Mom](phone://1234567890)
+xylophone lesson [url](https://www.apple.com/page?login=true)
+X 2012-01-01 Make [resolutions](:/52f6a750feea486eb336eafcfe92e596)
+(A) x Find ticket prices [url to click](https://www.url.net) @Travel
+complicated url https://www.apple.com [https://www.apple.com](https://www.apple.com)
+""".components(separatedBy: CharacterSet.newlines))
+    XCTAssertNotNil(ex1.value[0].title)
+    XCTAssertNotNil(ex1.value[1].title)
+    XCTAssertNotNil(ex1.value[2].title)
+    XCTAssertNotNil(ex1.value[3].title)
+    XCTAssertNotNil(ex1.value[4].title)
+  }
 }


### PR DESCRIPTION
This project is great and touches on many new and interesting things in modern swift.
I took it upon myself to add to it so that the canonical tests from the official todo.txt spec passed on the lib, hope that helps

- generic key:value support beyond "due:"
- completion/creation dates at the beginning of the line where needed/used
- multiple contexts/projects
- a few fixes to pass the official tests